### PR TITLE
feat: RedisConfig 키, 값의 serializer 설정

### DIFF
--- a/src/main/java/com/fitable/backend/config/RedisConfig.java
+++ b/src/main/java/com/fitable/backend/config/RedisConfig.java
@@ -19,6 +19,15 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
+        // String serializer for keys
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        // JSON serializer for values
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
+
         return template;
     }
 }


### PR DESCRIPTION
- Redis에 객체 저장 위해서는 직렬화 필요