### PR TITLE
feat: application.properties Redis 직렬화 설정 추가

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,8 +29,8 @@ jwt.accessTokenExpireTime=21600000
 jwt.refreshTokenExpireTime=604800000
 
 # Redis config
-# Redis ?? ?? ??
 spring.redis.host=43.201.248.185
 spring.redis.port=6379
 spring.redis.password=
 spring.redis.database=0
+spring.session.redis.serializer=generic-jackson


### PR DESCRIPTION
- JdkSerializationRedisSerializer 대신 GenericJackson2JsonRedisSerializer를 사용하도록 설정
- Serializable 구현할 필요 없이 RedisConfig를 통해 이용