### PR TITLE
feat: docker-compose.yml nginx 컨테이너 HTTP, HTTPS 포트포워딩

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     image: nginx:latest
     container_name: nginx-container
     ports:
-      - "80:80"
-      - "443:443"
+      - "8082:80"
+      - "8443:443"
     volumes:
       - /etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro  # 호스트의 절대 경로 사용
       - /etc/nginx/certs:/etc/ssl/certs:ro


### PR DESCRIPTION
- 기존의 80, 443은 로컬 nginx에서 사용 중
- 로컬 nginx는 실제 SSL 발급 및 관리에 사용, 도커 nginx는 젠킨스와 연결에 사용