### PR TITLE
feat: SecurityConfig Options 요청은 인증 없이 허용

### DIFF
--- a/src/main/java/com/fitable/backend/config/SecurityConfig.java
+++ b/src/main/java/com/fitable/backend/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.fitable.backend.config;
 import com.fitable.backend.filter.JwtRequestFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -32,8 +33,10 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(authorize -> authorize
+                        // CORS 사전 요청(OPTIONS)은 인증 없이 허용
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // 로그인 및 회원가입 경로는 인증 없이 접근 가능
-                        .requestMatchers("api/users/login", "api/users/register").permitAll()
+                        .requestMatchers("/api/users/login", "/api/users/register").permitAll()
                         // 나머지 요청은 인증 필요
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
- CORS 사전 요청
- 브라우저의 Preflight 요청(CORS 사전 요청)을 처리하기 위해 OPTIONS 요청에 대해 인증 및 권한 체크를 건너뛰고 단순히 허용 응답을 반환하는 것은 표준적이고 일반적으로 사용되는 접근법