### PR TITLE
feat: docker-compose.yml /etc/letsencrypt 경로를 올바르게 참조하도록 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,10 +35,9 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /etc/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - /etc/nginx/sites-available/default:/etc/nginx/conf.d/default.conf
-      - /etc/nginx/certs:/etc/ssl/certs:ro
-      - /etc/nginx/keys:/etc/ssl/private:ro
+      - /etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /etc/nginx/sites-available/default:/etc/nginx/conf.d/default.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro  # 인증서 전체 디렉토리를 마운트
     depends_on:
       - fitable-app
     networks:


### PR DESCRIPTION
- /etc/nginx/sites-available/default 파일이 /etc/letsencrypt 경로를 올바르게 참조하도록 설정