### PR TITLE
feat:

### DIFF
--- a/src/main/java/com/fitable/backend/config/SecurityConfig.java
+++ b/src/main/java/com/fitable/backend/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -41,6 +42,8 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Stateless 모드 설정
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
 
         return http.build();


### PR DESCRIPTION
SecurityConfig 세션관리정책 STATELESS로 설정
- options 요청 200, 그다음 메인 post 요청에 403 에러
- Spring Security는 인증 정보를 HTTP 세션에 저장하여, 이후 요청에서도 인증 상태를 유지
- JWT 인증 방식에서는 HTTP 세션을 사용하지 않으므로, 세션 생성과 관련된 리소스 낭비를 방지하기 위해 SessionCreationPolicy.STATELESS를 설정