### PR TITLE
fix: SecurityConfig Redis Session ID가 변경되는 현상 보완: 세션고정방지 비활성화

### DIFF
--- a/src/main/java/com/fitable/backend/config/SecurityConfig.java
+++ b/src/main/java/com/fitable/backend/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,7 +19,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 @Configuration
 public class SecurityConfig {
@@ -42,6 +42,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화
+                .sessionManagement(session -> session
+                        .sessionFixation(SessionManagementConfigurer.SessionFixationConfigurer::none)
+                )
                 .securityContext(securityContext -> securityContext.requireExplicitSave(false)) //익명 인증 비활성화
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Stateless 모드 설정
@@ -67,7 +70,8 @@ public class SecurityConfig {
         config.setAllowedOriginPatterns(Arrays.asList(
                 "https://fitable.kro.kr",      // 프론트엔드 도메인
                 "https://api.fitable.kro.kr",  // API 도메인
-                "http://43.201.248.185" //테스트용 IP
+                "http://43.201.248.185", //테스트용 IP
+                "http://localhost:5173" //테스트용 로컬 프론트
         ));
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With"));


### PR DESCRIPTION
- 새로운 세션 ID로 Redis에 데이터가 저장되지 않음: 새 세션 ID를 사용하면서 이전 세션에 저장된 데이터를 찾을 수 없는 문제
- Spring Security의 기본 설정 중 하나인 SessionFixationProtection (세션고정방지) 비활성화 시켜 세션 ID 고정